### PR TITLE
handle undefined string

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,10 @@ var nonLocalhostDomainRE = /^[^\s\.]+\.\S{2,}$/;
  */
 
 function isUrl(string){
+  if (typeof string !== 'string') {
+    return false;
+  }
+
   var match = string.match(protocolAndDomainRE);
   if (!match) {
     return false;

--- a/test/index.js
+++ b/test/index.js
@@ -118,6 +118,22 @@ describe('is-url', function () {
     it('google.com', function () {
       assert(!url('google.com'));
     });
+
+    it('empty', function () {
+      assert(!url(''));
+    });
+
+    it('undef', function () {
+      assert(!url(undefined));
+    });
+
+    it('object', function () {
+      assert(!url({}));
+    });
+
+    it('re', function () {
+      assert(!url(/abc/));
+    });
   });
 
   describe('redos', function () {


### PR DESCRIPTION
Problem:
As reported in #19, PR #18 changed behavior on:
- undefined string
- non-strings

Solution:
Revert to pre-#18 behavior on non-strings: return false.

Test:
I added test cases to clarify this behavior.
It shouldn't happen again.